### PR TITLE
Fix for __udivti3 and __umodti3 error

### DIFF
--- a/patches/longlong.h.patch
+++ b/patches/longlong.h.patch
@@ -1,8 +1,17 @@
 diff --git a/mpi/longlong.h b/mpi/longlong.h
-index c299534..1272d0a 100644
+index 21bd1a7..2fdfed5 100644
 --- a/mpi/longlong.h
 +++ b/mpi/longlong.h
-@@ -1543,7 +1543,7 @@ extern USItype __udiv_qrnnd ();
+@@ -26,7 +26,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
+ #endif
+ 
+ /* On 64-bit, use 128-bit 'unsigned __int128' for UDWtype, if available. */
+-#if !defined (UDWtype) && SIZEOF_UNSIGNED___INT128 * 8 == W_TYPE_SIZE * 2
++#if ((!defined (UDWtype)) && ((SIZEOF_UNSIGNED___INT128 * 8) == (W_TYPE_SIZE * 2)) && (!defined(__MVS__)))
+ #  define UDWtype unsigned __int128
+ #endif
+ 
+@@ -1503,7 +1503,7 @@ extern USItype __udiv_qrnnd ();
  /***************************************
   *********** s390x/zSeries  ************
   ***************************************/


### PR DESCRIPTION
Fix for linker error in ntbtls :

IEW2456E 9207 SYMBOL __umodti3 UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM
          THE DESIGNATED CALL LIBRARY.
 IEW2456E 9207 SYMBOL __udivti3 UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM
          THE DESIGNATED CALL LIBRARY.
 IEW2689W 4C40 DEFINITION SIDE FILE IS NOT DEFINED.
FSUM3065 The LINKEDIT step ended with return code 8.
